### PR TITLE
Add includePrefixes option to selectively hash CSS custom properties

### DIFF
--- a/.changeset/add-include-prefixes.md
+++ b/.changeset/add-include-prefixes.md
@@ -1,0 +1,5 @@
+---
+"postcss-plugin-var-hash-postfix": minor
+---
+
+Add includePrefixes option to selectively hash CSS custom properties

--- a/README.md
+++ b/README.md
@@ -118,6 +118,41 @@ postCssVarHashPostfix({
 
 Note that this option will ignore _anything_ that starts with the string; with the example above, both `--ignore` and `--ignorethis` would not have a hash appended to them.
 
+### `includePrefixes`
+
+An array of strings for which only CSS Variables that start with the specified prefixes will have a hash appended to them. This is the inverse of `ignorePrefixes` - when provided, variables that don't match any of the prefixes will be left unchanged.
+
+```js
+// input: --my-app-color: blue; --other-var: green;
+
+postCssVarHashPostfix({
+  hash: "123abc",
+  includePrefixes: ["my-app"],
+});
+
+// output: --my-app-color-123abc: blue; --other-var: green;
+```
+
+This is useful when you want to hash only a specific subset of your CSS Variables, such as those belonging to a particular component library or namespace.
+
+Note that this option will include _anything_ that starts with the string; with the example above, both `--my-app-color` and `--my-app-theme` would have a hash appended to them.
+
+#### Using `includePrefixes` and `ignorePrefixes` together
+
+If both options are provided, `includePrefixes` is checked first to determine which variables to hash, then `ignorePrefixes` acts as a filter to exclude specific variables from that included set.
+
+```js
+// input: --my-app-color: blue; --my-app-internal: red; --other: green;
+
+postCssVarHashPostfix({
+  hash: "123abc",
+  includePrefixes: ["my-app"],
+  ignorePrefixes: ["my-app-internal"],
+});
+
+// output: --my-app-color-123abc: blue; --my-app-internal: red; --other: green;
+```
+
 ### `delimiter`
 
 Customize the delimiter used to separate the existing CSS Variable name and the hash.

--- a/index.js
+++ b/index.js
@@ -25,7 +25,24 @@ module.exports = (opts = {}) => {
         newDecl[alreadyProcessed] = true;
 
         if (newDecl.prop.startsWith("--")) {
-          if (
+          // Check if we should only include specific prefixes
+          if (opts.includePrefixes?.length > 0) {
+            const matchesIncludePrefix = opts.includePrefixes.some((prefix) => {
+              return newDecl.prop.startsWith("--" + prefix);
+            });
+            if (!matchesIncludePrefix) {
+              // do nothing because it doesn't match any includePrefixes
+            } else if (
+              opts.ignorePrefixes?.length > 0 &&
+              opts.ignorePrefixes.some((prefix) => {
+                return newDecl.prop.startsWith("--" + prefix);
+              })
+            ) {
+              // do nothing because it's in the ignorePrefixes
+            } else {
+              newDecl.prop += hash;
+            }
+          } else if (
             opts.ignorePrefixes?.length > 0 &&
             opts.ignorePrefixes.some((prefix) => {
               return newDecl.prop.startsWith("--" + prefix);
@@ -41,7 +58,27 @@ module.exports = (opts = {}) => {
           newDecl.value = newDecl.value.replace(
             /--([a-zA-Z0-9_-]+)/g,
             (_, varName) => {
-              if (
+              // Check if we should only include specific prefixes
+              if (opts.includePrefixes?.length > 0) {
+                const matchesIncludePrefix = opts.includePrefixes.some(
+                  (prefix) => {
+                    return varName.startsWith(prefix);
+                  },
+                );
+                if (!matchesIncludePrefix) {
+                  // do nothing because it doesn't match any includePrefixes
+                  return `--${varName}`;
+                } else if (
+                  opts.ignorePrefixes?.length > 0 &&
+                  opts.ignorePrefixes.some((prefix) => {
+                    return varName.startsWith(prefix);
+                  })
+                ) {
+                  // do nothing because it's in the ignorePrefixes
+                  return `--${varName}`;
+                }
+                return `--${varName}${hash}`;
+              } else if (
                 opts.ignorePrefixes?.length > 0 &&
                 opts.ignorePrefixes.some((prefix) => {
                   return varName.startsWith(prefix);
@@ -69,7 +106,31 @@ module.exports = (opts = {}) => {
         const newAtRule = atRule.clone();
         newAtRule[alreadyProcessed] = true;
 
-        if (
+        // Check if we should only include specific prefixes
+        if (opts.includePrefixes?.length > 0) {
+          const matchesIncludePrefix = opts.includePrefixes.some((prefix) => {
+            return newAtRule.params.startsWith("--" + prefix);
+          });
+          if (!matchesIncludePrefix) {
+            // do nothing because it doesn't match any includePrefixes
+          } else if (
+            opts.ignorePrefixes?.length > 0 &&
+            opts.ignorePrefixes.some((prefix) => {
+              return newAtRule.params.startsWith("--" + prefix);
+            })
+          ) {
+            // do nothing because it's in the ignorePrefixes
+          } else {
+            if (atRule.name === "container") {
+              newAtRule.params = newAtRule.params.replace(
+                /^(--[a-zA-Z0-9_-]+)/,
+                `$1${hash}`,
+              );
+            } else {
+              newAtRule.params += hash;
+            }
+          }
+        } else if (
           opts.ignorePrefixes?.length > 0 &&
           opts.ignorePrefixes.some((prefix) => {
             return newAtRule.params.startsWith("--" + prefix);

--- a/index.test.js
+++ b/index.test.js
@@ -267,3 +267,146 @@ test("works with named @container queries and container-names that start with --
     },
   );
 });
+
+test("only transforms properties that start with the includePrefixes", async () => {
+  await run("a{ --include: 123; }", "a{ --include-hash: 123; }", {
+    hash: "hash",
+    includePrefixes: ["include"],
+  });
+});
+
+test("doesn't transform properties that don't match includePrefixes", async () => {
+  await run("a{ --test: 123; }", "a{ --test: 123; }", {
+    hash: "hash",
+    includePrefixes: ["include"],
+  });
+});
+
+test("uses multiple includePrefixes for properties", async () => {
+  await run(
+    "a{ --include: 123; --include2: 123; }",
+    "a{ --include-hash: 123; --include2-hash: 123; }",
+    {
+      hash: "hash",
+      includePrefixes: ["include", "include2"],
+    },
+  );
+});
+
+test("only transforms values that start with the includePrefixes", async () => {
+  await run("a{ color: var(--include); }", "a{ color: var(--include-hash); }", {
+    hash: "hash",
+    includePrefixes: ["include"],
+  });
+});
+
+test("doesn't transform values that don't match includePrefixes", async () => {
+  await run("a{ color: var(--test); }", "a{ color: var(--test); }", {
+    hash: "hash",
+    includePrefixes: ["include"],
+  });
+});
+
+test("uses multiple includePrefixes for values", async () => {
+  await run(
+    "a{ color: var(--include); background-color: var(--allow); }",
+    "a{ color: var(--include-hash); background-color: var(--allow-hash); }",
+    {
+      hash: "hash",
+      includePrefixes: ["include", "allow"],
+    },
+  );
+});
+
+test("includes some and not others for properties", async () => {
+  await run(
+    "a{ --include: 123; --test: 123; }",
+    "a{ --include-hash: 123; --test: 123; }",
+    {
+      hash: "hash",
+      includePrefixes: ["include"],
+    },
+  );
+});
+
+test("includes some and not others for values", async () => {
+  await run(
+    "a{ color: var(--include); background-color: var(--test); }",
+    "a{ color: var(--include-hash); background-color: var(--test); }",
+    {
+      hash: "hash",
+      includePrefixes: ["include"],
+    },
+  );
+});
+
+test("works with complex nested values and vars and includes only some", async () => {
+  await run(
+    "a{ color: var(--test, var(--include, var(--test3, rebeccapurple))); }",
+    "a{ color: var(--test, var(--include-hash, var(--test3, rebeccapurple))); }",
+    {
+      hash: "hash",
+      includePrefixes: ["include"],
+    },
+  );
+});
+
+test("works with at-rules and includePrefixes", async () => {
+  await run("@property --include {}", "@property --include-hash {}", {
+    hash: "hash",
+    includePrefixes: ["include"],
+  });
+});
+
+test("doesn't transform at-rules that don't match includePrefixes", async () => {
+  await run("@property --test {}", "@property --test {}", {
+    hash: "hash",
+    includePrefixes: ["include"],
+  });
+});
+
+test("works with @container queries and includePrefixes", async () => {
+  await run(
+    "@container --include (min-width: 100px) {} .container { container-name: --include; }",
+    "@container --include-hash (min-width: 100px) {} .container { container-name: --include-hash; }",
+    {
+      hash: "hash",
+      includePrefixes: ["include"],
+    },
+  );
+});
+
+test("doesn't transform @container queries that don't match includePrefixes", async () => {
+  await run(
+    "@container --test (min-width: 100px) {} .container { container-name: --test; }",
+    "@container --test (min-width: 100px) {} .container { container-name: --test; }",
+    {
+      hash: "hash",
+      includePrefixes: ["include"],
+    },
+  );
+});
+
+test("includePrefixes and ignorePrefixes work together - include wins", async () => {
+  await run(
+    "a{ --include: 123; --test: 123; }",
+    "a{ --include-hash: 123; --test: 123; }",
+    {
+      hash: "hash",
+      includePrefixes: ["include"],
+      ignorePrefixes: ["test"],
+    },
+  );
+});
+
+test("includePrefixes and ignorePrefixes work together - ignore filters included", async () => {
+  await run(
+    "a{ --include: 123; --include-ignore: 123; }",
+    "a{ --include-hash: 123; --include-ignore: 123; }",
+    {
+      hash: "hash",
+      includePrefixes: ["include"],
+      ignorePrefixes: ["include-ignore"],
+    },
+  );
+});

--- a/index.test.js
+++ b/index.test.js
@@ -284,11 +284,11 @@ test("doesn't transform properties that don't match includePrefixes", async () =
 
 test("uses multiple includePrefixes for properties", async () => {
   await run(
-    "a{ --include: 123; --include2: 123; }",
-    "a{ --include-hash: 123; --include2-hash: 123; }",
+    "a{ --include: 123; --theme: 123; }",
+    "a{ --include-hash: 123; --theme-hash: 123; }",
     {
       hash: "hash",
-      includePrefixes: ["include", "include2"],
+      includePrefixes: ["include", "theme"],
     },
   );
 });


### PR DESCRIPTION
## Summary
This PR introduces a new `includePrefixes` option that allows users to specify which CSS custom properties should be hashed based on their prefix. This is the inverse of the existing `ignorePrefixes` option.

## Changes
- Added `includePrefixes` option to the plugin
- When provided, only CSS custom properties starting with the specified prefixes will have the hash appended
- Works across:
  - CSS custom property declarations (`--prefix-var`)
  - `var()` references in values
  - `@property` at-rules
  - `@container` named queries
- If both `includePrefixes` and `ignorePrefixes` are provided, `includePrefixes` is checked first, then `ignorePrefixes` acts as a filter on the included set

## Example Usage
```javascript
postcss([
  plugin({
    hash: "abc123",
    includePrefixes: ["my-app", "theme"]
  })
])
```

This will hash `--my-app-color` and `--theme-primary` but NOT `--other-var`.

## Test plan
- ✅ Added 15 comprehensive tests covering all scenarios
- ✅ All 43 tests passing
- ✅ Linting and formatting checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)